### PR TITLE
Fixed for v81

### DIFF
--- a/LethalHands/LethalHands.cs
+++ b/LethalHands/LethalHands.cs
@@ -111,7 +111,7 @@ namespace LethalHands
                 switch (itemMode)
                 {
                     case ItemMode.All:
-                        playerControllerInstance.DropAllHeldItemsAndSync();
+                        playerControllerInstance.DropAllHeldItemsAndSyncNonexact();
                         break;
                     case ItemMode.MainSlots:
                         DropMainItems((int)playerControllerInstance.playerClientId);


### PR DESCRIPTION
They changed the DropAllHeldItemsAndSync function to require args, but using DropAllHeldItemsAndSyncNonexact instead with no args still works. Tested and it syncs over the network correctly.

Fixes https://github.com/ThomasNg2/LethalHands/issues/13